### PR TITLE
update ch8

### DIFF
--- a/langevin_dynamics.lyx
+++ b/langevin_dynamics.lyx
@@ -1,16 +1,16 @@
-#LyX 2.4 created this file. For more info see https://www.lyx.org/
-\lyxformat 620
+#LyX 2.3 created this file. For more info see http://www.lyx.org/
+\lyxformat 544
 \begin_document
 \begin_header
 \save_transient_properties true
 \origin unavailable
 \textclass optbook
 \use_default_options true
-\maintain_unincluded_children no
+\maintain_unincluded_children false
 \language english
 \language_package default
-\inputencoding auto-legacy
-\fontencoding auto
+\inputencoding auto
+\fontencoding global
 \font_roman "default" "default"
 \font_sans "default" "default"
 \font_typewriter "default" "default"
@@ -18,9 +18,7 @@
 \font_default_family default
 \use_non_tex_fonts false
 \font_sc false
-\font_roman_osf false
-\font_sans_osf false
-\font_typewriter_osf false
+\font_osf false
 \font_sf_scale 100 100
 \font_tt_scale 100 100
 \use_microtype false
@@ -52,9 +50,7 @@
 \suppress_date false
 \justification true
 \use_refstyle 1
-\use_formatted_ref 0
 \use_minted 0
-\use_lineno 0
 \index Index
 \shortcut idx
 \color #008000
@@ -70,29 +66,22 @@
 \papercolumns 1
 \papersides 1
 \paperpagestyle default
-\tablestyle default
 \tracking_changes false
 \output_changes false
-\change_bars false
-\postpone_fragile_content false
 \html_math_output 0
 \html_css_as_file 0
 \html_be_strict false
-\docbook_table_output 0
-\docbook_mathml_prefix 1
 \end_header
 
 \begin_body
 
 \begin_layout Standard
 Sampling in high dimension is a fundamental problem.
- Informally,
- given access to a function 
+ Informally, given access to a function 
 \begin_inset Formula $f:\R^{n}\rightarrow\R\cup\left\{ \infty\right\} $
 \end_inset
 
-,
- the sampling problem is to generate a point 
+, the sampling problem is to generate a point 
 \begin_inset Formula $x\in\R^{n}$
 \end_inset
 
@@ -101,25 +90,22 @@ Sampling in high dimension is a fundamental problem.
 \end_inset
 
 .
- Note that any density can be written in this form,
- so this is completely general.
- To make the problem precise,
- we also have to specify a starting point with positive density,
- and an error parameter 
+ Note that any density can be written in this form, so this is completely
+ general.
+ To make the problem precise, we also have to specify a starting point with
+ positive density, and an error parameter 
 \begin_inset Formula $\epsilon$
 \end_inset
 
- that measures the distance of the distribution of the output from the desired target.
+ that measures the distance of the distribution of the output from the desired
+ target.
  
 \end_layout
 
 \begin_layout Standard
-Unfortunately,
- in this generality,
- just like optimization,
- sampling is also intractable.
- To see this,
- consider the following function:
+Unfortunately, in this generality, just like optimization, sampling is also
+ intractable.
+ To see this, consider the following function:
 \begin_inset Formula 
 \[
 f(x)=\begin{cases}
@@ -147,16 +133,11 @@ for some closed set
 \begin_inset Formula $S$
 \end_inset
 
-,
- which could,
- e.g.,
- be the minimizer of a hard-to-optimize function.
+, which could, e.g., be the minimizer of a hard-to-optimize function.
 \end_layout
 
 \begin_layout Standard
-Consider a second example,
- which might appear more tractable:
- 
+Consider a second example, which might appear more tractable: 
 \begin_inset Formula 
 \[
 g(x)=e^{-\frac{1}{2}x^{\top}Ax}\one_{x\ge0}.
@@ -164,13 +145,12 @@ g(x)=e^{-\frac{1}{2}x^{\top}Ax}\one_{x\ge0}.
 
 \end_inset
 
-Without the restriction to the nonnegative orthant,
- the target density is the Gaussian 
+Without the restriction to the nonnegative orthant, the target density is
+ the Gaussian 
 \begin_inset Formula $N(0,A^{-1})$
 \end_inset
 
-,
- and can be sampled by first sampling the standard Gaussian 
+, and can be sampled by first sampling the standard Gaussian 
 \begin_inset Formula $N(0,I)$
 \end_inset
 
@@ -183,24 +163,20 @@ Without the restriction to the nonnegative orthant,
 \begin_inset Formula $\R^{n}$
 \end_inset
 
-,
- we can sample each coordinate independently from 
+, we can sample each coordinate independently from 
 \begin_inset Formula $N(0,1$
 \end_inset
 
-),
- a problem which has many (efficient) numerical recipes.
- But how can we handle the restriction?
- In the course of forthcoming chapters,
- we will see that this problem and its generalization to sampling logconcave densities,
- i.e.,
- when 
+), a problem which has many (efficient) numerical recipes.
+ But how can we handle the restriction? In the course of forthcoming chapters,
+ we will see that this problem and its generalization to sampling logconcave
+ densities, i.e., when 
 \begin_inset Formula $f$
 \end_inset
 
- is convex,
- can be solved in polynomial time.
- It is remarkable that the polynomial-time frontier for both optimization and sampling is essentially determined by convexity.
+ is convex, can be solved in polynomial time.
+ It is remarkable that the polynomial-time frontier for both optimization
+ and sampling is essentially determined by convexity.
 \end_layout
 
 \begin_layout Standard
@@ -210,37 +186,36 @@ We begin with gradient-based sampling methods.
 \end_inset
 
 .
- These methods will in fact be natural algorithmic versions of continuous processes on random variables,
- a particularly pleasing connection.
+ These methods will in fact be natural algorithmic versions of continuous
+ processes on random variables, a particularly pleasing connection.
  Later we will see methods that only use access to 
 \begin_inset Formula $f$
 \end_inset
 
-,
- and others that utilize higher derivatives,
- notably the Hessian.
+, and others that utilize higher derivatives, notably the Hessian.
  The parallels to optimization will be pervasive and striking.
 \end_layout
 
 \begin_layout Section
-Gradient-based methods:
- Langevin Dynamics
+Gradient-based methods: Langevin Dynamics
 \end_layout
 
 \begin_layout Standard
-Here we study a simple stochastic process for generating samples from a desired distribution 
+Here we study a simple stochastic process for generating samples from a
+ desired distribution 
 \begin_inset Formula $e^{-f(x)}$
 \end_inset
 
 .
- As we will see later in this chapter,
- it can also be viewed as a stochastic version of gradient descent 
+ As we will see later in this chapter, it can also be viewed as a stochastic
+ version of gradient descent 
 \emph on
 in the space of measures
 \emph default
 .
- While gradient descent corresponds to an ordinary differential equation (ODE),
- stochastic gradient descent corresponds to a stochastic differential equation (SDE).
+ While gradient descent corresponds to an ordinary differential equation
+ (ODE), stochastic gradient descent corresponds to a stochastic differential
+ equation (SDE).
 \end_layout
 
 \begin_layout Standard
@@ -310,7 +285,6 @@ SetAlgoLined
 
 \series bold
 Input:
-
 \series default
  Initial point 
 \begin_inset Formula $x_{0}\in\Rn$
@@ -331,7 +305,6 @@ dx_{t}=-\nabla f(x_{t})dt+\sqrt{2}dW_{t}
 
 \series bold
 Output:
-
 \series default
  
 \begin_inset Formula $x_{t}$
@@ -361,8 +334,7 @@ Here
 \begin_inset Formula $f:\R^{n}\rightarrow\R$
 \end_inset
 
- is a function,
- 
+ is a function, 
 \begin_inset Formula $x_{t}$
 \end_inset
 
@@ -375,7 +347,8 @@ Here
 \end_inset
 
  is infinitesimal Brownian motion also known as a Wiener process.
- We can view it as the continuous version of the following discrete process 
+ We can view it as the continuous version of the following discrete process
+ 
 \begin_inset Formula 
 \[
 x_{t+1}=x_{t}-h\nabla f(x_{t})+\sqrt{2h}\zeta_{t}
@@ -396,8 +369,7 @@ with
 \begin_inset Formula $h\rightarrow0$
 \end_inset
 
-,
- this discrete process converges to the continuous one.
+, this discrete process converges to the continuous one in distribution.
  We discuss the continuous version first.
 \end_layout
 
@@ -419,16 +391,13 @@ dx_{t}=\mu(x_{t},t)dt+\sigma(x_{t},t)dW_{t}
 \end_inset
 
  is a time-varying linear transformation.
- The simplest such process is the Wiener process:
- 
+ The simplest such process is the Wiener process: 
 \begin_inset Formula $dx_{t}=dW_{t}$
 \end_inset
 
- which finds many applications in applied mathematics,
- finance,
- biology and physics.
- Another useful process is the Ornstein-Ulhenbeck Process:
- 
+ which finds many applications in applied mathematics, finance, biology
+ and physics.
+ Another useful process is the Ornstein-Ulhenbeck Process: 
 \end_layout
 
 \begin_layout Standard
@@ -439,20 +408,21 @@ dx_{t}=-ax_{t}dt+\sigma dW_{t}
 
 \end_inset
 
-This represents a particle moving in a fluid,
- the first term being the force of friction exerted on the particle and the second term being the movement caused by other particles colliding in our particle,
- which is modeled using Brownian motion.
+This represents a particle moving in a fluid, the first term being the force
+ of friction exerted on the particle and the second term being the movement
+ caused by other particles colliding in our particle, which is modeled using
+ Brownian motion.
  
 \end_layout
 
 \begin_layout Standard
-A crucial difference between ordinary differentials and stochastic differentials is in the chain rule.
+A crucial difference between ordinary differentials and stochastic differentials
+ is in the chain rule.
  Unlike classical differentials where we have 
 \begin_inset Formula $df(x)=\nabla f(x)dx$
 \end_inset
 
-,
- we have the following chain rule for stochastic calculus.
+, we have the following chain rule for stochastic calculus.
 \end_layout
 
 \begin_layout Lemma
@@ -501,8 +471,7 @@ For any process
 \begin_inset Formula $\sigma(x_{t})\in\R^{n\times m}$
 \end_inset
 
-,
- we have that
+, we have that
 \begin_inset Formula 
 \begin{align*}
 df(x_{t}) & =\nabla f(x_{t})^{\top}dx_{t}+\frac{1}{2}(dx_{t})^{\top}\nabla^{2}f(x_{t})(dx_{t})\\
@@ -516,27 +485,56 @@ df(x_{t}) & =\nabla f(x_{t})^{\top}dx_{t}+\frac{1}{2}(dx_{t})^{\top}\nabla^{2}f(
 
 \begin_layout Standard
 The usual chain rule comes from using Taylor expansion and taking a limit,
- i.e.,
- 
+ i.e., 
 \begin_inset Formula 
 \[
-\nabla f(x+hy)=\lim_{h\rightarrow0}\frac{f(x)+h\nabla f(x)^{\top}y+\frac{1}{2}h^{2}...}{h}
+\nabla f(x)=\lim_{h\rightarrow0}\frac{(f(x)+h\nabla f(x)^{\top}y+\frac{1}{2}h^{2}...)-f(x)}{h}=\lim_{h\rightarrow0}\frac{h\nabla f(x)^{\top}y+\frac{1}{2}h^{2}...}{h}
 \]
 
 \end_inset
 
-and only the first term survives,
- as the second and later terms goes to zero.
- But with the stochastic component,
- roughly speaking,
- 
+and only the first term survives, as the second and later terms goes to
+ zero.
+ But with the stochastic component, roughly speaking, 
 \begin_inset Formula $(dW_{t})^{2}=dt$
 \end_inset
 
-,
- and we need to keep track of the second term in the Taylor expansion as well.
- For a detailed treatment of stochastic calculus,
- we refer the reader to a standard textbook such as 
+
+\begin_inset Foot
+status open
+
+\begin_layout Plain Layout
+By definition, 
+\begin_inset Formula $W_{t}\sim N(0,t)$
+\end_inset
+
+, so the variance of 
+\begin_inset Formula $W_{t}$
+\end_inset
+
+ is 
+\begin_inset Formula $t$
+\end_inset
+
+.
+ Thus, 
+\begin_inset Formula $(dW_{t})^{2}=dt$
+\end_inset
+
+ may seem to make sene.
+ This can be justified rigorously through 
+\emph on
+quadratic variations
+\emph default
+.
+\end_layout
+
+\end_inset
+
+, and we need to keep track of the second term in the Taylor expansion as
+ well.
+ For a detailed treatment of stochastic calculus, we refer the reader to
+ a standard textbook such as 
 \begin_inset CommandInset citation
 LatexCommand cite
 key "oksendal2013stochastic"
@@ -549,13 +547,13 @@ literal "false"
 \end_layout
 
 \begin_layout Standard
-First,
- we will see that 
+First, we will see that 
 \begin_inset Formula $e^{-f}$
 \end_inset
 
  is a stationary density for the Langevin SDE in continuous time.
- The proof relies on the following general theorem about the distribution induced by an SDE.
+ The proof relies on the following general theorem about the distribution
+ induced by an SDE.
 \end_layout
 
 \begin_layout Theorem
@@ -628,8 +626,7 @@ For any smooth function
 \begin_inset Formula $\phi$
 \end_inset
 
-,
- we have that
+, we have that
 \begin_inset Formula 
 \[
 \E_{x\sim p_{t}}\phi(x)=\E\phi(x_{t}).
@@ -641,8 +638,7 @@ Taking derivatives on the both sides with respect to
 \begin_inset Formula $t$
 \end_inset
 
-,
- using It
+, using It
 \begin_inset ERT
 status open
 
@@ -659,17 +655,14 @@ status open
 \begin_inset CommandInset ref
 LatexCommand ref
 reference "lem:itos"
-nolink "false"
 
 \end_inset
 
-),
- and noting that 
+), and noting that 
 \begin_inset Formula $\E dW_{t}=0$
 \end_inset
 
-,
- we have that
+, we have that
 \begin_inset Formula 
 \begin{align*}
 \int\phi(x)dp_{t}(x)dx & =\E\left(\nabla\phi(x_{t})^{\top}\mu(x_{t})dt+\nabla\phi(x_{t})^{\top}\sigma(x_{t})dW_{t}+\frac{1}{2}\tr(\sigma(x_{t})^{\top}\nabla^{2}\phi(x_{t})\sigma(x_{t}))dt\right)\\
@@ -682,8 +675,7 @@ Using
 \begin_inset Formula $x_{t}\sim p_{t}$
 \end_inset
 
-,
- we have that
+, we have that
 \begin_inset Formula 
 \[
 \int\phi(x)\frac{dp_{t}}{dt}dx=\int\nabla\phi(x)^{\top}\mu(x)p_{t}(x)+\frac{1}{2}\tr(\nabla^{2}\phi(x)D(x))p_{t}(x)dx.
@@ -691,8 +683,7 @@ Using
 
 \end_inset
 
-Integrating by parts,
- 
+Integrating by parts, 
 \begin_inset Formula 
 \[
 \int\nabla\phi(x)^{\top}\mu(x)p_{t}(x)dx=-\int\phi(x)\sum_{i}\frac{\partial}{\partial x_{i}}(\mu_{i}(x)p_{t}(x))dx.
@@ -700,8 +691,7 @@ Integrating by parts,
 
 \end_inset
 
-Similarly,
- integrating by parts twice gives
+Similarly, integrating by parts twice gives
 \begin_inset Formula 
 \begin{align*}
 \int\tr(\sigma(x)^{\top}\nabla^{2}\phi(x)\sigma(x))p_{t}(x)dx & =\int\tr(\nabla^{2}\phi(x)\sigma(x)\sigma(x)^{\top})p_{t}(x)dx\\
@@ -711,8 +701,7 @@ Similarly,
 
 \end_inset
 
-Hence,
- 
+Hence, 
 \begin_inset Formula 
 \[
 \int\phi(x)\left[\frac{dp_{t}}{dt}+\sum_{i}\frac{\partial}{\partial x_{i}}(\mu(x)_{i}p_{t}(x))-\frac{1}{2}\sum_{i,j}\frac{\partial^{2}}{\partial x_{i}\partial x_{j}}\left[(D(x))_{ij}p_{t}(x)\right]\right]dx=0
@@ -725,8 +714,7 @@ for any smooth
 \end_inset
 
 .
- Therefore,
- we have the conclusion of the theorem.
+ Therefore, we have the conclusion of the theorem.
 \end_layout
 
 \begin_layout Proof
@@ -744,8 +732,7 @@ For any smooth function
 \begin_inset Formula $f$
 \end_inset
 
-,
- the density proportional to 
+, the density proportional to 
 \begin_inset Formula $F=e^{-f}$
 \end_inset
 
@@ -757,7 +744,6 @@ The Fokker–Planck equation (Theorem
 \begin_inset CommandInset ref
 LatexCommand ref
 reference "thm:fokker_planck"
-nolink "false"
 
 \end_inset
 
@@ -816,8 +802,7 @@ Consider the equation
 \begin_inset Formula $\mathcal{N}(0,t)$
 \end_inset
 
-,
- i.e.
+, i.e.
  
 \begin_inset Formula 
 \[
@@ -846,8 +831,7 @@ Consider the SDE with
 \begin_inset Formula $X_{t}\in\R^{n}$
 \end_inset
 
-:
- 
+: 
 \begin_inset Formula 
 \[
 dX_{t}=-X_{t}dt+\sqrt{2}dW_{t}.
@@ -874,8 +858,7 @@ status open
 \end_inset
 
 .
- (Hint:
- Take expectation on both sides of It
+ (Hint: Take expectation on both sides of It
 \begin_inset ERT
 status open
 
@@ -892,8 +875,7 @@ status open
 \begin_inset Formula $f(X_{t})$
 \end_inset
 
-,
- and use 
+, and use 
 \begin_inset Formula $\E df(X_{t})=d\E f(X_{t})$
 \end_inset
 
@@ -910,14 +892,13 @@ status open
 \end_layout
 
 \begin_layout Subsection
-Convergence via Coupling in Wasserstein distance.
+Convergence via Coupling in Wasserstein distance
 \end_layout
 
 \begin_layout Standard
-Next we turn to the rate of convergence,
- which will also prove uniqueness of the stationary distribution for the stochastic process.
- For this,
- we assume that 
+Next we turn to the rate of convergence, which will also prove uniqueness
+ of the stationary distribution for the stochastic process.
+ For this, we assume that 
 \begin_inset Formula $f$
 \end_inset
 
@@ -935,26 +916,24 @@ literal "false"
 \end_layout
 
 \begin_layout Standard
-Our goal is to bound the rate at which the distribution of the current point approaches the stationary distribution,
- in some chosen measure of distance between distributions (for example,
- the TV distance).
- To do this,
- in the coupling technique,
- we consider two points which are both following the random process.
- One of them is already in the stationary distribution,
- and therefore will stay there.
+Our goal is to bound the rate at which the distribution of the current point
+ approaches the stationary distribution, in some chosen measure of distance
+ between distributions (for example, the TV distance).
+ To do this, in the coupling technique, we consider two points which are
+ both following the random process.
+ One of them is already in the stationary distribution, and therefore will
+ stay there.
  The other is our point.
- We will show that there is a coupling of the two distributions,
- i.e.,
- a joint distribution over the two points,
- whose marginals are identical to the single point processes,
- such that the expected distance between the two points decreases at a certain rate.
- More formally,
- we couple two copies 
+ We will show that there is a coupling of the two distributions, i.e., a joint
+ distribution over the two points, whose marginals are identical to the
+ single point processes, such that the expected distance between the two
+ points decreases at a certain rate.
+ More formally, we couple two copies 
 \begin_inset Formula $x_{t},y_{t}$
 \end_inset
 
- of the random process with different starting points (the coupling is a joint distribution 
+ of the random process with different starting points (the coupling is a
+ joint distribution 
 \begin_inset Formula $D(x_{t},y_{t})$
 \end_inset
 
@@ -962,15 +941,15 @@ Our goal is to bound the rate at which the distribution of the current point app
 \begin_inset Formula $x_{t},y_{t}$
 \end_inset
 
- is exactly the process) and show that their distributions get closer over time.
+ is exactly the process) and show that their distributions get closer over
+ time.
  
 \end_layout
 
 \begin_layout Standard
-While the challenge usually is to find a good coupling,
- in the present case,
- the simple identity coupling (i.e.,
- the same Wiener process is used for both 
+While the challenge usually is to find a good coupling, in the present case,
+ the simple identity coupling (i.e., the same Wiener process is used for both
+ 
 \begin_inset Formula $x_{t}$
 \end_inset
 
@@ -979,15 +958,14 @@ While the challenge usually is to find a good coupling,
 \end_inset
 
 ) works well.
- The distance measure we will use here is the Wasserstein distance (in Euclidean norm,
- see Definition 
+ The distance measure we will use here is the Wasserstein distance (in Euclidean
+ norm, see Definition 
 \begin_inset CommandInset ref
 LatexCommand ref
 reference "defn:The-Wassestein--distance"
 plural "false"
 caps "false"
 noprefix "false"
-nolink "false"
 
 \end_inset
 
@@ -996,8 +974,8 @@ nolink "false"
 \end_layout
 
 \begin_layout Exercise
-Show that for two distributions with the same finite support,
- computing their Wasserstein distance reduces to a bipartite matching problem.
+Show that for two distributions with the same finite support, computing
+ their Wasserstein distance reduces to a bipartite matching problem.
  
 \end_layout
 
@@ -1015,8 +993,7 @@ Let
 \end_inset
 
 .
- Then,
- there is a coupling 
+ Then, there is a coupling 
 \begin_inset Formula $\gamma$
 \end_inset
 
@@ -1040,10 +1017,8 @@ Let
 \end_layout
 
 \begin_layout Proof
-From the definition of LD,
- and by using the identity coupling,
- i.e.,
- the same Gaussian 
+From the definition of LD, and by using the identity coupling, i.e., the same
+ Gaussian 
 \begin_inset Formula $dW_{t}$
 \end_inset
 
@@ -1055,8 +1030,7 @@ From the definition of LD,
 \begin_inset Formula $y_{t}$
 \end_inset
 
-,
- we have that 
+, we have that 
 \begin_inset Formula 
 \[
 \frac{d}{dt}\left(x_{t}-y_{t}\right)=\nabla f(y_{t})-\nabla f(x_{t}).
@@ -1064,8 +1038,7 @@ From the definition of LD,
 
 \end_inset
 
-Hence,
- 
+Hence, 
 \begin_inset Formula 
 \[
 \frac{1}{2}\frac{d}{dt}\|x_{t}-y_{t}\|^{2}=\left\langle \nabla f(y_{t})-\nabla f(x_{t}),x_{t}-y_{t}\right\rangle .
@@ -1073,13 +1046,11 @@ Hence,
 
 \end_inset
 
-Next,
- from the strong convexity of 
+Next, from the strong convexity of 
 \begin_inset Formula $f$
 \end_inset
 
-,
- we have 
+, we have 
 \begin_inset Formula 
 \begin{align*}
 f(y_{t})-f(x_{t}) & \ge\nabla f(x_{t})^{\top}(y_{t}-x_{t})+\frac{\mu}{2}\norm{x_{t}-y_{t}}^{2},\\
@@ -1088,8 +1059,7 @@ f(x_{t})-f(y_{t}) & \ge\nabla f(y_{t})^{\top}(x_{t}-y_{t})+\frac{\mu}{2}\norm{x_
 
 \end_inset
 
-Adding two equations together,
- we have
+Adding two equations together, we have
 \begin_inset Formula 
 \[
 (\nabla f(x_{t})-\nabla f(y_{t}))^{\top}(x_{t}-y_{t})\geq\mu\norm{x_{t}-y_{t}}^{2}.
@@ -1097,8 +1067,7 @@ Adding two equations together,
 
 \end_inset
 
-Therefore,
- 
+Therefore, 
 \begin_inset Formula 
 \[
 \frac{1}{2}\frac{d}{dt}\|x_{t}-y_{t}\|^{2}\leq-\mu\|x_{t}-y_{t}\|^{2}.
@@ -1106,8 +1075,7 @@ Therefore,
 
 \end_inset
 
- Hence,
- 
+ Hence, 
 \begin_inset Formula 
 \begin{align*}
 \frac{d}{dt}\log\|x_{t}-y_{t}\|^{2} & =\frac{\frac{d}{dt}\|x_{t}-y_{t}\|^{2}}{\|x_{t}-y_{t}\|^{2}}\\
@@ -1124,8 +1092,7 @@ Integrating both sides from
 \begin_inset Formula $t$
 \end_inset
 
-,
- we get 
+, we get 
 \begin_inset Formula 
 \[
 \log\|x_{t}-y_{t}\|^{2}-\log\|x_{0}-y_{0}\|^{2}\le-2\mu t
@@ -1177,9 +1144,10 @@ Convergence in
 \end_layout
 
 \begin_layout Standard
-Next we analyze the convergence of Langevin dynamics in the two most commonly used divergence metrics.
- The rate of mixing will depend on a fundamental functional constants of the target density,
- which we define next.
+Next we analyze the convergence of Langevin dynamics in the two most commonly
+ used divergence metrics.
+ The rate of mixing will depend on a fundamental functional constants of
+ the target density, which we define next.
  These constants will play an important role in later algorithms and analysis,
  and we will also see equivalent geometric formulations of them.
 \end_layout
@@ -1274,7 +1242,7 @@ log-Sobolev inequality
 ,
 \begin_inset Formula 
 \begin{equation}
-\Ent_{\pi}(g^{2})\leq2C_{LSI}(\nu)\,\E_{\nu}\left(\norm{\nabla g}^{2}\right)]\label{eq:lsi}
+\Ent_{\nu}(g^{2})\leq2C_{LSI}(\nu)\,\E_{\nu}\left(\norm{\nabla g}^{2}\right)]\label{eq:lsi}
 \end{equation}
 
 \end_inset
@@ -1311,7 +1279,28 @@ dx_{t}=-\nabla f(x)dt+\sqrt{2}dW_{t}
 
 \end_inset
 
-converges exponentially in KL-divergence to the density 
+converges exponentially in KL-divergence (Definition
+\begin_inset ERT
+status open
+
+\begin_layout Plain Layout
+
+~
+\end_layout
+
+\end_inset
+
+
+\begin_inset CommandInset ref
+LatexCommand ref
+reference "defn:KL-divergence"
+plural "false"
+caps "false"
+noprefix "false"
+
+\end_inset
+
+) to the density 
 \begin_inset Formula $\nu(x)\propto e^{-f(x)}$
 \end_inset
 
@@ -1319,9 +1308,7 @@ converges exponentially in KL-divergence to the density
 \begin_inset Formula $O(C_{LSI})$
 \end_inset
 
-,
- i.e.,
- the distribution 
+, i.e., the distribution 
 \begin_inset Formula $\rho_{t}$
 \end_inset
 
@@ -1349,8 +1336,7 @@ For a target distribution
 \begin_inset Formula $\nu$
 \end_inset
 
-,
- with 
+, with 
 \begin_inset Formula $\rho_{t}$
 \end_inset
 
@@ -1358,13 +1344,11 @@ For a target distribution
 \begin_inset Formula $t$
 \end_inset
 
-,
- starting at 
+, starting at 
 \begin_inset Formula $\rho_{0}$
 \end_inset
 
-,
- we have
+, we have
 \begin_inset Formula 
 \[
 \frac{d}{dt}d_{KL}(\rho_{t},\nu)=-J_{\nu}(\rho_{t})
@@ -1384,8 +1368,7 @@ where
 \begin_inset Formula $\nu$
 \end_inset
 
-,
- defined as 
+, defined as 
 \begin_inset Formula $\E_{\rho}(\norm{\nabla\log(\rho/\nu)}^{2})$
 \end_inset
 
@@ -1418,7 +1401,8 @@ We compute the time derivative of the distribution of LD at time
 \end_layout
 
 \begin_layout Standard
-The next lemma shows that the log-Sobolev constant can be equivalently formulated in terms of distributions in place of smooth functions.
+The next lemma shows that the log-Sobolev constant can be equivalently formulate
+d in terms of distributions in place of smooth functions.
 \end_layout
 
 \begin_layout Lemma
@@ -1430,8 +1414,7 @@ The log-Sobolev constant of a distribution
 \begin_inset Formula $\R^{n}$
 \end_inset
 
-can be equivalently defined as follows:
- for any distribution 
+can be equivalently defined as follows: for any distribution 
 \begin_inset Formula $\rho$
 \end_inset
 
@@ -1439,8 +1422,7 @@ can be equivalently defined as follows:
 \begin_inset Formula $\R^{n}$
 \end_inset
 
-,
- we have
+, we have
 \begin_inset Formula 
 \[
 d_{KL}(\rho,\nu)\le\frac{C_{LSI}}{2}J_{\nu}(\rho).
@@ -1452,13 +1434,11 @@ d_{KL}(\rho,\nu)\le\frac{C_{LSI}}{2}J_{\nu}(\rho).
 \end_layout
 
 \begin_layout Proof
-To go one way,
- we use 
+To go one way, we use 
 \begin_inset Formula $g=\sqrt{\frac{\rho}{\nu}};$
 \end_inset
 
-to go the other way,
- define 
+to go the other way, define 
 \begin_inset Formula $\rho=\frac{g^{2}}{\E_{\nu}(g^{2})}$
 \end_inset
 
@@ -1473,7 +1453,6 @@ reference "thm:LDinKL"
 plural "false"
 caps "false"
 noprefix "false"
-nolink "false"
 
 \end_inset
 
@@ -1525,8 +1504,22 @@ status open
 
 \end_layout
 
-\begin_layout Section
-Langevin Dynamics is Gradient Descent in Density Space*
+\begin_layout Standard
+\begin_inset ERT
+status open
+
+\begin_layout Plain Layout
+
+
+\backslash
+section{Langevin Dynamics is Gradient Descent in Density Space*
+\backslash
+footnote{Sections marked with * are more mathematical and can be skipped.}}
+\end_layout
+
+\end_inset
+
+
 \begin_inset CommandInset label
 LatexCommand label
 name "sec:LD_GD"
@@ -1534,6 +1527,11 @@ name "sec:LD_GD"
 \end_inset
 
 
+\begin_inset Note Note
+status open
+
+\begin_layout Plain Layout
+Langevin Dynamics is Gradient Descent in Density Space*
 \begin_inset Foot
 status open
 
@@ -1546,8 +1544,14 @@ Sections marked with * are more mathematical and can be skipped.
 
 \end_layout
 
+\end_inset
+
+
+\end_layout
+
 \begin_layout Standard
-Here we show that Langevin dynamics is simply gradient descent for the function 
+Here we show that Langevin dynamics is simply gradient descent for the function
+ 
 \begin_inset Formula $F(\rho)=\KL(\rho\|\nu)$
 \end_inset
 
@@ -1564,8 +1568,7 @@ Here we show that Langevin dynamics is simply gradient descent for the function
 \end_inset
 
  is the current density.
- For this,
- we first define the Wasserstein space.
+ For this, we first define the Wasserstein space.
 \end_layout
 
 \begin_layout Definition
@@ -1627,8 +1630,7 @@ For any
 \begin_inset Formula $v\in T_{p}P_{2}(\Rn)$
 \end_inset
 
-,
- we can write 
+, we can write 
 \begin_inset Formula $v(x)=\nabla\cdot(p(x)\nabla\lambda(x))$
 \end_inset
 
@@ -1641,8 +1643,7 @@ For any
 \end_inset
 
 .
- Furthermore,
- the local norm of 
+ Furthermore, the local norm of 
 \begin_inset Formula $v$
 \end_inset
 
@@ -1679,8 +1680,7 @@ Let
 \begin_inset Formula $\Rn$
 \end_inset
 
- as follows:
- Consider the process 
+ as follows: Consider the process 
 \begin_inset Formula $x_{0}\sim p$
 \end_inset
 
@@ -1702,12 +1702,10 @@ Let
 \begin_inset Formula $\frac{d}{dt}p_{t}$
 \end_inset
 
-,
- we follow the same idea as in the proof as Theorem 
+, we follow the same idea as in the proof as Theorem 
 \begin_inset CommandInset ref
 LatexCommand ref
 reference "thm:fokker_planck"
-nolink "false"
 
 \end_inset
 
@@ -1716,8 +1714,7 @@ nolink "false"
 \begin_inset Formula $\phi$
 \end_inset
 
-,
- we have that 
+, we have that 
 \begin_inset Formula $\E_{x\sim p_{t}}\phi(x)=\E\phi(x_{t}).$
 \end_inset
 
@@ -1725,8 +1722,7 @@ nolink "false"
 \begin_inset Formula $t$
 \end_inset
 
-,
- we have that
+, we have that
 \begin_inset Formula 
 \[
 \int\phi(x)\frac{d}{dt}p_{t}(x)dx=\int\nabla\phi(x)^{\top}c(x)p_{t}(x)dx=-\int\nabla\cdot(c(x)p_{t}(x))\phi(x)dx
@@ -1739,8 +1735,7 @@ where we used integration by parts at the end.
 \begin_inset Formula $\phi$
 \end_inset
 
-,
- we have that
+, we have that
 \begin_inset Formula 
 \[
 \frac{dp_{t}(x)}{dt}=-\nabla\cdot(p_{t}(x)c(x)).
@@ -1748,8 +1743,8 @@ where we used integration by parts at the end.
 
 \end_inset
 
-Since we are interested only in vector fields that generate the minimum movement in Wasserstein distance,
- we consider the optimization problem
+Since we are interested only in vector fields that generate the minimum
+ movement in Wasserstein distance, we consider the optimization problem
 \begin_inset Formula 
 \[
 \min_{-\nabla\cdot(pc)=v}\frac{1}{2}\int p(x)\|c(x)\|^{2}dx
@@ -1775,8 +1770,7 @@ where we can think
 \end_inset
 
 .
- Then,
- the problem becomes
+ Then, the problem becomes
 \begin_inset Formula 
 \begin{align*}
  & \min_{c}\frac{1}{2}\int p(x)\|c(x)\|^{2}dx-\int\lambda(x)\nabla\cdot(p(x)c(x))dx.\\
@@ -1785,8 +1779,8 @@ where we can think
 
 \end_inset
 
-Now,
- we note that the problem is a pointwise optimization problem whose minimizer is given by
+Now, we note that the problem is a pointwise optimization problem whose
+ minimizer is given by
 \begin_inset Formula 
 \[
 c(x)=-\nabla\lambda(x).
@@ -1794,13 +1788,14 @@ c(x)=-\nabla\lambda(x).
 
 \end_inset
 
-This proves that any vector field that generates minimum movement in Wasserstein distance is a gradient field.
- Also,
- we have that 
+This proves that any vector field that generates minimum movement in Wasserstein
+ distance is a gradient field.
+ Also, we have that 
 \begin_inset Formula $v(x)=\nabla\cdot(p(x)\nabla\lambda(x)).$
 \end_inset
 
- Note that the right hand side is an elliptical differential equation and hence for any 
+ Note that the right hand side is an elliptical differential equation and
+ hence for any 
 \begin_inset Formula $v$
 \end_inset
 
@@ -1808,14 +1803,12 @@ This proves that any vector field that generates minimum movement in Wasserstein
 \begin_inset Formula $\int v(x)dx=0$
 \end_inset
 
-,
- there is an unique solution 
+, there is an unique solution 
 \begin_inset Formula $\lambda(x)$
 \end_inset
 
 .
- Therefore,
- we can write 
+ Therefore, we can write 
 \begin_inset Formula $v(x)=\nabla\cdot(p(x)\nabla\lambda(x))$
 \end_inset
 
@@ -1827,8 +1820,7 @@ This proves that any vector field that generates minimum movement in Wasserstein
 \end_layout
 
 \begin_layout Proof
-Next,
- we note that the movement is given by
+Next, we note that the movement is given by
 \begin_inset Formula 
 \[
 \|v\|_{p}^{2}=\int p(x)\|c(x)\|^{2}dx=\E_{x\sim p}\|\nabla\lambda(x)\|^{2}.
@@ -1840,21 +1832,20 @@ Next,
 \end_layout
 
 \begin_layout Standard
-As we discussed in the gradient descent section,
- one can use norms other than 
+As we discussed in the gradient descent section, one can use norms other
+ than 
 \begin_inset Formula $\ell_{2}$
 \end_inset
 
  norm.
- For the Wasserstein space,
- we should use the local norm as given in Lemma 
+ For the Wasserstein space, we should use the local norm as given in Lemma
+ 
 \begin_inset CommandInset ref
 LatexCommand ref
 reference "lem:local-norm"
 plural "false"
 caps "false"
 noprefix "false"
-nolink "false"
 
 \end_inset
 
@@ -1872,13 +1863,13 @@ Let
 \begin_inset Formula $\rho_{t}$
 \end_inset
 
- be the density of the distribution produced by Langevin Dynamics for the target distribution 
+ be the density of the distribution produced by Langevin Dynamics for the
+ target distribution 
 \begin_inset Formula $\nu=e^{-f(x)}/\int e^{-f(y)}dy$
 \end_inset
 
 .
- Then,
- we have that
+ Then, we have that
 \begin_inset Formula 
 \[
 \frac{d\rho}{dt}=\argmin_{v\in T_{p}P_{2}(\Rn)}\left\langle \nabla F(\rho),v\right\rangle _{p}+\frac{1}{2}\|v\|_{p}^{2}.
@@ -1886,12 +1877,12 @@ Let
 
 \end_inset
 
-Namely,
- 
+Namely, 
 \begin_inset Formula $\rho_{t}$
 \end_inset
 
- follows continuous gradient descent in the density space for the function 
+ follows continuous gradient descent in the density space for the function
+ 
 \begin_inset Formula $F(\rho)=\KL(\rho\|\nu)$
 \end_inset
 
@@ -1903,8 +1894,7 @@ For any function
 \begin_inset Formula $c$
 \end_inset
 
-,
- the optimization problem of interest satisfies
+, the optimization problem of interest satisfies
 \begin_inset Formula 
 \[
 \min_{\delta=\nabla\cdot(\rho\nabla\lambda)}\left\langle c,\delta\right\rangle +\frac{1}{2}\int\rho(x)\|\nabla\lambda(x)\|^{2}dx=\min_{\nabla\lambda}-\int\rho(x)\cdot\nabla c(x)^{\top}\nabla\lambda(x)dx+\frac{1}{2}\int\rho(x)\|\nabla\lambda(x)\|^{2}dx.
@@ -1912,8 +1902,7 @@ For any function
 
 \end_inset
 
-Solving the right hand side,
- we have 
+Solving the right hand side, we have 
 \begin_inset Formula $\nabla c=\nabla\lambda$
 \end_inset
 
@@ -1922,14 +1911,12 @@ Solving the right hand side,
 \end_inset
 
 .
- Now,
- we note that 
+ Now, we note that 
 \begin_inset Formula $\nabla F(\rho)=\log\frac{\rho}{\nu}-1$
 \end_inset
 
 .
- Therefore,
- 
+ Therefore, 
 \begin_inset Formula 
 \begin{align*}
 \frac{d\rho}{dt} & =\nabla\cdot(\rho\nabla(\log\frac{\rho}{\nu}-1))\\
@@ -1943,7 +1930,6 @@ which is exactly equal to (
 \begin_inset CommandInset ref
 LatexCommand ref
 reference "eq:dp_LD"
-nolink "false"
 
 \end_inset
 
@@ -1952,8 +1938,8 @@ nolink "false"
 \end_layout
 
 \begin_layout Standard
-To analyze this continuous descent in Wasserstein space,
- we first prove that continuous gradient descent converges exponentially whenever 
+To analyze this continuous descent in Wasserstein space, we first prove
+ that continuous gradient descent converges exponentially whenever 
 \begin_inset Formula $F$
 \end_inset
 
@@ -1996,14 +1982,11 @@ on the manifold with the metric
 \end_inset
 
  is the gradient on the manifold.
- Then,
- the process 
+ Then, the process 
 \begin_inset Formula $dx_{t}=-\nabla F(x_{t})dt$
 \end_inset
 
- converges exponentially,
- i.e.,
- 
+ converges exponentially, i.e., 
 \begin_inset Formula $F(x_{t})-\min_{y}F(y)\le e^{-\alpha t}(F(x_{0})-\min_{y}F(y))$
 \end_inset
 
@@ -2023,8 +2006,7 @@ The conclusion follows.
 \end_layout
 
 \begin_layout Standard
-Finally,
- we note that the log-Sobolev inequality for the density 
+Finally, we note that the log-Sobolev inequality for the density 
 \begin_inset Formula $\nu$
 \end_inset
 
@@ -2032,7 +2014,6 @@ Finally,
 \begin_inset CommandInset ref
 LatexCommand ref
 reference "eq:LD_strong_convexity"
-nolink "false"
 
 \end_inset
 
@@ -2051,14 +2032,11 @@ Fix a density
 \end_inset
 
 .
- Then the log-Sobolev inequality,
- namely,
- for every smooth function 
+ Then the log-Sobolev inequality, namely, for every smooth function 
 \begin_inset Formula $g$
 \end_inset
 
-,
- 
+, 
 \begin_inset Formula 
 \[
 \frac{C_{LSI}}{2}\int\norm{\nabla g}^{2}\,d\nu\ge\int g(x)^{2}\log g(x)^{2}\ d\nu
@@ -2070,7 +2048,6 @@ Fix a density
 \begin_inset CommandInset ref
 LatexCommand ref
 reference "eq:LD_strong_convexity"
-nolink "false"
 
 \end_inset
 
@@ -2086,8 +2063,7 @@ Take
 \begin_inset Formula $g(x)=\sqrt{\frac{\rho(x)}{\nu(x)}}$
 \end_inset
 
-,
- the log-Sobolev inequality shows that 
+, the log-Sobolev inequality shows that 
 \begin_inset Formula 
 \[
 \frac{C_{LSI}}{2}\int\rho(x)\norm{\nabla\log\frac{\rho(x)}{\nu(x)}}^{2}\,dx\geq\int\rho(x)\log\frac{\rho(x)}{\nu(x)}\,dx\text{ for all }\rho.
@@ -2103,12 +2079,10 @@ As we calculate in Theorem
 \begin_inset CommandInset ref
 LatexCommand ref
 reference "thm:LD_GD"
-nolink "false"
 
 \end_inset
 
-,
- we have that
+, we have that
 \begin_inset Formula 
 \[
 \norm{\nabla F(\rho)}_{\rho}^{2}=\int\rho(x)\norm{\nabla\log\frac{\rho(x)}{\nu(x)}}^{2}\,dx.
@@ -2116,12 +2090,10 @@ nolink "false"
 
 \end_inset
 
-Therefore,
- this is exactly the condition (
+Therefore, this is exactly the condition (
 \begin_inset CommandInset ref
 LatexCommand ref
 reference "eq:LD_strong_convexity"
-nolink "false"
 
 \end_inset
 
@@ -2137,7 +2109,6 @@ Combining Lemma
 \begin_inset CommandInset ref
 LatexCommand ref
 reference "lem:log_sob_LD"
-nolink "false"
 
 \end_inset
 
@@ -2145,19 +2116,16 @@ nolink "false"
 \begin_inset CommandInset ref
 LatexCommand ref
 reference "lem:grad-dom"
-nolink "false"
 
 \end_inset
 
-,
- we obtain another proof of Therem 
+, we obtain another proof of Therem 
 \begin_inset CommandInset ref
 LatexCommand ref
 reference "thm:LDinKL"
 plural "false"
 caps "false"
 noprefix "false"
-nolink "false"
 
 \end_inset
 
@@ -2169,22 +2137,23 @@ Discussion
 \end_layout
 
 \begin_layout Standard
-Langevin dynamics converges quickly in continuous time for isoperimetric distributions.
- Turning this into an efficient algorithm typically needs more assumptions and there is much room for choosing discretizations.
+Langevin dynamics converges quickly in continuous time for isoperimetric
+ distributions.
+ Turning this into an efficient algorithm typically needs more assumptions
+ and there is much room for choosing discretizations.
  This is similar to the situation with gradient descent for optimization.
  As we saw in Section 
 \begin_inset CommandInset ref
 LatexCommand ref
 reference "sec:LD_GD"
-nolink "false"
 
 \end_inset
 
-,
- it turns out that Langevin dynamics is in fact gradient descent in the space of probability measures under the Wasserstein metric,
- where the function being minimized is the KL-divergence of the current density from the target stationary density.
- For more on this view of sampling as optimization over measures,
- see 
+, it turns out that Langevin dynamics is in fact gradient descent in the
+ space of probability measures under the Wasserstein metric, where the function
+ being minimized is the KL-divergence of the current density from the target
+ stationary density.
+ For more on this view of sampling as optimization over measures, see 
 \begin_inset CommandInset citation
 LatexCommand cite
 key "wibisono2018sampling"
@@ -2206,8 +2175,7 @@ literal "true"
 \begin_inset Formula $D$
 \end_inset
 
-,
- the log-Sobolev constant is 
+, the log-Sobolev constant is 
 \begin_inset Formula $\Omega(1/D)$
 \end_inset
 

--- a/main.lyx
+++ b/main.lyx
@@ -1,5 +1,5 @@
-#LyX 2.4 created this file. For more info see https://www.lyx.org/
-\lyxformat 620
+#LyX 2.3 created this file. For more info see http://www.lyx.org/
+\lyxformat 544
 \begin_document
 \begin_header
 \save_transient_properties true
@@ -16,6 +16,7 @@
 \usepackage[small,bf]{caption}
 \usepackage{tikz}
 \usepackage{enumitem}
+\usepackage[stable]{footmisc}
 \setlist{nolistsep}
 \usepackage{hyperref}
 \hypersetup{
@@ -27,11 +28,11 @@
 }
 \end_preamble
 \use_default_options true
-\maintain_unincluded_children no
+\maintain_unincluded_children false
 \language english
 \language_package none
-\inputencoding auto-legacy
-\fontencoding auto
+\inputencoding auto
+\fontencoding global
 \font_roman "default" "default"
 \font_sans "default" "default"
 \font_typewriter "default" "default"
@@ -39,15 +40,13 @@
 \font_default_family default
 \use_non_tex_fonts false
 \font_sc false
-\font_roman_osf false
-\font_sans_osf false
-\font_typewriter_osf false
+\font_osf false
 \font_sf_scale 100 100
 \font_tt_scale 100 100
 \use_microtype false
 \use_dash_ligatures true
 \graphics default
-\default_output_format default
+\default_output_format pdf2
 \output_sync 0
 \bibtex_command default
 \index_command default
@@ -75,9 +74,7 @@
 \suppress_date false
 \justification true
 \use_refstyle 1
-\use_formatted_ref 0
 \use_minted 0
-\use_lineno 0
 \index Index
 \shortcut idx
 \color #008000
@@ -93,16 +90,11 @@
 \papercolumns 1
 \papersides 1
 \paperpagestyle default
-\tablestyle default
 \tracking_changes false
 \output_changes false
-\change_bars false
-\postpone_fragile_content false
 \html_math_output 0
 \html_css_as_file 0
 \html_be_strict false
-\docbook_table_output 0
-\docbook_mathml_prefix 1
 \end_header
 
 \begin_body
@@ -361,11 +353,9 @@ status collapsed
 
 \begin_layout Plain Layout
 yintat@uw.edu.
- This work is supported in part by CCF-1749609,
- DMS-1839116,
- DMS-2023166,
- Microsoft Research Faculty Fellowship,
- Sloan Research Fellowship and Packard Fellowships.
+ This work is supported in part by CCF-1749609, DMS-1839116, DMS-2023166,
+ Microsoft Research Faculty Fellowship, Sloan Research Fellowship and Packard
+ Fellowships.
 \end_layout
 
 \end_inset
@@ -401,9 +391,8 @@ status collapsed
 
 \begin_layout Plain Layout
 vempala@gatech.edu.
- This work is supported in part by CCF-1563838,
- E2CDA-1640081,
- CCF-1717349 and DMS-1839323.
+ This work is supported in part by CCF-1563838, E2CDA-1640081, CCF-1717349
+ and DMS-1839323.
 \end_layout
 
 \end_inset
@@ -607,8 +596,7 @@ Black-box Problem
 
 \begin_deeper
 \begin_layout Itemize
-Gradient descent,
- etc
+Gradient descent, etc
 \end_layout
 
 \end_deeper
@@ -685,8 +673,7 @@ Newton method?
 status open
 
 \begin_layout Plain Layout
-in general,
- 
+in general, 
 \end_layout
 
 \begin_layout Plain Layout
@@ -702,12 +689,13 @@ in general,
 \end_layout
 
 \begin_layout Plain Layout
--- some discussion at beginning and end of chapter (like the story you plan to tell in lecture) but I agree with your plan for both to sign off each section
+-- some discussion at beginning and end of chapter (like the story you plan
+ to tell in lecture) but I agree with your plan for both to sign off each
+ section
 \end_layout
 
 \begin_layout Plain Layout
-– use more displaystyle math (separate line),
- easier to read and reference
+– use more displaystyle math (separate line), easier to read and reference
 \end_layout
 
 \begin_layout Plain Layout
@@ -724,8 +712,7 @@ in general,
 status open
 
 \begin_layout Plain Layout
-For the Langevin dynamics,
- give example of SDE.
+For the Langevin dynamics, give example of SDE.
 \end_layout
 
 \begin_layout Plain Layout
@@ -737,8 +724,8 @@ add figures (lots!)
 \end_layout
 
 \begin_layout Plain Layout
-Mirror descent section:
- Define the parameter of the mirror map..highlight what is the result for 
+Mirror descent section: Define the parameter of the mirror map..highlight
+ what is the result for 
 \begin_inset Formula $\ell_{1}$
 \end_inset
 
@@ -747,8 +734,7 @@ Mirror descent section:
 \end_inset
 
  ball.
- Also,
- the SDP ball.
+ Also, the SDP ball.
 \end_layout
 
 \begin_layout Plain Layout
@@ -793,38 +779,18 @@ Make the book mathematically rigorous?
 
 \begin_layout Plain Layout
 —
-
 \end_layout
 
 \begin_layout Plain Layout
-Acknowledge:
- Swati,
- Andre Wibisono,
- Mohit Singh,
- Arkadi,
- Siva Theja Magaluri,
+Acknowledge: Swati, Andre Wibisono, Mohit Singh, Arkadi, Siva Theja Magaluri,
  ...
 \end_layout
 
 \begin_layout Plain Layout
-Minor acknowledge:
- Ollin Boer Bohan,
- Ewin Tang,
- Andrew Wei,
- Omid Sadeghi,
- XiuJun Li,
- Ofir Press,
- Cyrus Hettle,
- Jiaming Lang,
- Samantha Petti,
- Matthew Fahrbach,
- Ziyi Yin,
- rafael orozco,
- Kunal Chawla,
- Anand Chaturvedi,
- Letian Chen,
- Huang Zan,
- Pranshu Trivedi
+Minor acknowledge: Ollin Boer Bohan, Ewin Tang, Andrew Wei, Omid Sadeghi,
+ XiuJun Li, Ofir Press, Cyrus Hettle, Jiaming Lang, Samantha Petti, Matthew
+ Fahrbach, Ziyi Yin, rafael orozco, Kunal Chawla, Anand Chaturvedi, Letian
+ Chen, Huang Zan, Pranshu Trivedi
 \end_layout
 
 \begin_layout Plain Layout
@@ -836,13 +802,11 @@ Explain the lagrangian somewhere
 \end_layout
 
 \begin_layout Plain Layout
-Add defs of Wasserstein,
- log-Sob
+Add defs of Wasserstein, log-Sob
 \end_layout
 
 \begin_layout Plain Layout
 —
-
 \end_layout
 
 \begin_layout Plain Layout
@@ -907,7 +871,6 @@ Preliminaries
 \begin_inset CommandInset include
 LatexCommand input
 filename "preliminaries.lyx"
-literal "true"
 
 \end_inset
 
@@ -918,7 +881,6 @@ literal "true"
 \begin_inset CommandInset include
 LatexCommand input
 filename "examples.lyx"
-literal "true"
 
 \end_inset
 
@@ -933,7 +895,6 @@ Introduction
 \begin_inset CommandInset include
 LatexCommand input
 filename "convexity.lyx"
-literal "true"
 
 \end_inset
 
@@ -953,23 +914,21 @@ Maybe I can add a plot somewhere looks like this:
 \end_layout
 
 \begin_layout Plain Layout
-Sublinear time --- SGD (close to quadratic,
- 1/eps)
+Sublinear time --- SGD (close to quadratic, 1/eps)
 \end_layout
 
 \begin_layout Plain Layout
-Linear time --- GD (close to quadratic ,
- log(1/eps)) n^{1.5-2.5} time --- 
+Linear time --- GD (close to quadratic , log(1/eps)) n^{1.5-2.5} time ---
+ 
 \end_layout
 
 \begin_layout Plain Layout
-IPM (structure,
- log(1/eps)) n^3 time --- 
+IPM (structure, log(1/eps)) n^3 time --- 
 \end_layout
 
 \begin_layout Plain Layout
-cutting plane (log(1/eps)) n^O(1) time --- (exact if solution is integral and bounded) 2^{exp(sqrt(n)} time --- (structure,
- exact if soln is integral)
+cutting plane (log(1/eps)) n^O(1) time --- (exact if solution is integral
+ and bounded) 2^{exp(sqrt(n)} time --- (structure, exact if soln is integral)
 \end_layout
 
 \end_inset
@@ -985,7 +944,6 @@ Gradient Descent
 \begin_inset CommandInset include
 LatexCommand input
 filename "gradient_descent.lyx"
-literal "true"
 
 \end_inset
 
@@ -1007,7 +965,6 @@ name "chap:Elimination"
 \begin_inset CommandInset include
 LatexCommand input
 filename "cutting_plane.lyx"
-literal "true"
 
 \end_inset
 
@@ -1015,7 +972,6 @@ literal "true"
 \begin_inset CommandInset include
 LatexCommand input
 filename "geometric_descent.lyx"
-literal "true"
 
 \end_inset
 
@@ -1023,7 +979,6 @@ literal "true"
 \begin_inset CommandInset include
 LatexCommand input
 filename "lower_bound.lyx"
-literal "true"
 
 \end_inset
 
@@ -1038,7 +993,6 @@ Reduction
 \begin_inset CommandInset include
 LatexCommand input
 filename "equivalence.lyx"
-literal "true"
 
 \end_inset
 
@@ -1047,12 +1001,12 @@ literal "true"
 status open
 
 \begin_layout Plain Layout
-I don't like the current outline where I couple the equivalence with the convex conjugate.
+I don't like the current outline where I couple the equivalence with the
+ convex conjugate.
 \end_layout
 
 \begin_layout Plain Layout
-For some people,
- the equivalence is not that important.
+For some people, the equivalence is not that important.
  But the convex conjugate is important for anyone.
 \end_layout
 
@@ -1062,7 +1016,6 @@ For some people,
 \begin_inset CommandInset include
 LatexCommand input
 filename "duality.lyx"
-literal "true"
 
 \end_inset
 
@@ -1095,7 +1048,6 @@ Just we never use in that way?
 \begin_inset CommandInset include
 LatexCommand input
 filename "mirror_descent.lyx"
-literal "true"
 
 \end_inset
 
@@ -1132,14 +1084,14 @@ Is mirror descent is about the decomposition of online and offline parts?
 status open
 
 \begin_layout Plain Layout
-Incorporate some of the contents after I have introduced the subgradient method
+Incorporate some of the contents after I have introduced the subgradient
+ method
 \end_layout
 
 \begin_layout Plain Layout
 \begin_inset CommandInset include
 LatexCommand input
 filename "reduction.lyx"
-literal "true"
 
 \end_inset
 
@@ -1155,7 +1107,6 @@ literal "true"
 \begin_inset CommandInset include
 LatexCommand input
 filename "frank_wolfe.lyx"
-literal "true"
 
 \end_inset
 
@@ -1163,7 +1114,6 @@ literal "true"
 \begin_inset CommandInset include
 LatexCommand input
 filename "newton_method.lyx"
-literal "true"
 
 \end_inset
 
@@ -1171,7 +1121,6 @@ literal "true"
 \begin_inset CommandInset include
 LatexCommand input
 filename "interior_point_method.lyx"
-literal "true"
 
 \end_inset
 
@@ -1186,7 +1135,6 @@ Sparsification
 \begin_inset CommandInset include
 LatexCommand input
 filename "subspace_embedding.lyx"
-literal "true"
 
 \end_inset
 
@@ -1194,7 +1142,6 @@ literal "true"
 \begin_inset CommandInset include
 LatexCommand input
 filename "leverage_score_sampling.lyx"
-literal "true"
 
 \end_inset
 
@@ -1202,7 +1149,6 @@ literal "true"
 \begin_inset CommandInset include
 LatexCommand input
 filename "stochastic_gradient_descent.lyx"
-literal "true"
 
 \end_inset
 
@@ -1217,7 +1163,6 @@ Acceleration
 \begin_inset CommandInset include
 LatexCommand input
 filename "chebyshev.lyx"
-literal "true"
 
 \end_inset
 
@@ -1225,7 +1170,6 @@ literal "true"
 \begin_inset CommandInset include
 LatexCommand input
 filename "conjugate_gradient.lyx"
-literal "true"
 
 \end_inset
 
@@ -1233,7 +1177,6 @@ literal "true"
 \begin_inset CommandInset include
 LatexCommand input
 filename "accelerated_gradient_descent.lyx"
-literal "true"
 
 \end_inset
 
@@ -1252,7 +1195,6 @@ Gradient-based Sampling
 \begin_inset CommandInset include
 LatexCommand input
 filename "langevin_dynamics.lyx"
-literal "true"
 
 \end_inset
 
@@ -1267,7 +1209,6 @@ Elimination and Reduction
 \begin_inset CommandInset include
 LatexCommand input
 filename "cutting_plane_volume.lyx"
-literal "true"
 
 \end_inset
 
@@ -1278,7 +1219,6 @@ literal "true"
 \begin_inset CommandInset include
 LatexCommand input
 filename "opt_from_mem.lyx"
-literal "true"
 
 \end_inset
 
@@ -1293,7 +1233,6 @@ Geometrization
 \begin_inset CommandInset include
 LatexCommand input
 filename "ball_walk.lyx"
-literal "true"
 
 \end_inset
 
@@ -1301,7 +1240,6 @@ literal "true"
 \begin_inset CommandInset include
 LatexCommand input
 filename "har_dikin.lyx"
-literal "true"
 
 \end_inset
 
@@ -1309,7 +1247,6 @@ literal "true"
 \begin_inset CommandInset include
 LatexCommand input
 filename "RHMC.lyx"
-literal "true"
 
 \end_inset
 
@@ -1331,7 +1268,6 @@ name "chap:Annealing"
 \begin_inset CommandInset include
 LatexCommand input
 filename "annealing.lyx"
-literal "true"
 
 \end_inset
 
@@ -1339,7 +1275,6 @@ literal "true"
 \begin_inset CommandInset include
 LatexCommand input
 filename "annealing_volume.lyx"
-literal "true"
 
 \end_inset
 
@@ -1351,7 +1286,6 @@ status open
 \begin_inset CommandInset include
 LatexCommand input
 filename "rounding.lyx"
-literal "true"
 
 \end_inset
 
@@ -1391,7 +1325,6 @@ Calculus - Review
 \begin_inset CommandInset include
 LatexCommand input
 filename "appendix.lyx"
-literal "true"
 
 \end_inset
 
@@ -1400,8 +1333,8 @@ literal "true"
 status open
 
 \begin_layout Plain Layout
-Probably should first have a more comprehensive introduction,
- covering what we need to use in this book..
+Probably should first have a more comprehensive introduction, covering what
+ we need to use in this book..
 \end_layout
 
 \end_inset
@@ -1417,7 +1350,6 @@ Notation
 \begin_inset CommandInset include
 LatexCommand input
 filename "notation.lyx"
-literal "true"
 
 \end_inset
 
@@ -1438,8 +1370,7 @@ end{document}
 \end_layout
 
 \begin_layout Chapter
-—
--
+—-
 \end_layout
 
 \begin_layout Chapter
@@ -1450,7 +1381,6 @@ Expansion
 \begin_inset CommandInset include
 LatexCommand input
 filename "ode.lyx"
-literal "true"
 
 \end_inset
 
@@ -1458,7 +1388,6 @@ literal "true"
 \begin_inset CommandInset include
 LatexCommand input
 filename "collocation_method.lyx"
-literal "true"
 
 \end_inset
 
@@ -1473,7 +1402,6 @@ Decomposition
 \begin_inset CommandInset include
 LatexCommand input
 filename "cholesky_decomposition.lyx"
-literal "true"
 
 \end_inset
 
@@ -1481,7 +1409,6 @@ literal "true"
 \begin_inset CommandInset include
 LatexCommand input
 filename "multigrid.lyx"
-literal "true"
 
 \end_inset
 

--- a/preliminaries.lyx
+++ b/preliminaries.lyx
@@ -1,16 +1,16 @@
-#LyX 2.4 created this file. For more info see https://www.lyx.org/
-\lyxformat 620
+#LyX 2.3 created this file. For more info see http://www.lyx.org/
+\lyxformat 544
 \begin_document
 \begin_header
 \save_transient_properties true
 \origin unavailable
 \textclass optbook
 \use_default_options true
-\maintain_unincluded_children no
+\maintain_unincluded_children false
 \language english
 \language_package default
-\inputencoding auto-legacy
-\fontencoding auto
+\inputencoding auto
+\fontencoding global
 \font_roman "default" "default"
 \font_sans "default" "default"
 \font_typewriter "default" "default"
@@ -18,9 +18,7 @@
 \font_default_family default
 \use_non_tex_fonts false
 \font_sc false
-\font_roman_osf false
-\font_sans_osf false
-\font_typewriter_osf false
+\font_osf false
 \font_sf_scale 100 100
 \font_tt_scale 100 100
 \use_microtype false
@@ -52,9 +50,7 @@
 \suppress_date false
 \justification true
 \use_refstyle 1
-\use_formatted_ref 0
 \use_minted 0
-\use_lineno 0
 \index Index
 \shortcut idx
 \color #008000
@@ -70,16 +66,11 @@
 \papercolumns 1
 \papersides 1
 \paperpagestyle default
-\tablestyle default
 \tracking_changes false
 \output_changes false
-\change_bars false
-\postpone_fragile_content false
 \html_math_output 0
 \html_css_as_file 0
 \html_be_strict false
-\docbook_table_output 0
-\docbook_mathml_prefix 1
 \end_header
 
 \begin_body
@@ -105,8 +96,7 @@ We use
 \begin_inset Formula $r$
 \end_inset
 
-:
- 
+: 
 \begin_inset Formula $\left\{ y:\norm{y-x}_{2}\le r\right\} $
 \end_inset
 
@@ -119,8 +109,7 @@ We use
 \begin_inset Formula $X$
 \end_inset
 
-,
- namely 
+, namely 
 \begin_inset Formula $\conv(X)=\{\sum\alpha_{i}x_{i}:\ \alpha_{i}\geq0,\sum\alpha_{i}=1,x_{i}\in X\}$
 \end_inset
 
@@ -150,9 +139,7 @@ We use
 \begin_inset Formula $x,y\in\Rn$
 \end_inset
 
-,
- we view them as column vectors,
- and use 
+, we view them as column vectors, and use 
 \begin_inset Formula $[x,y]$
 \end_inset
 
@@ -160,9 +147,7 @@ We use
 \begin_inset Formula $\conv(\{x,y\})$
 \end_inset
 
-,
- namely,
- the line segment between 
+, namely, the line segment between 
 \begin_inset Formula $x$
 \end_inset
 
@@ -195,13 +180,11 @@ We use
 status open
 
 \begin_layout Plain Layout
-Should we really abuse vector?
- Like 
+Should we really abuse vector? Like 
 \begin_inset Formula $f(x)_{i}=f(x_{i})$
 \end_inset
 
-?
- Or we use bold letter?
+? Or we use bold letter?
 \end_layout
 
 \end_inset
@@ -240,8 +223,7 @@ Probability measure.
 status open
 
 \begin_layout Plain Layout
-Manifold,
- tangent space.
+Manifold, tangent space.
 \end_layout
 
 \end_inset
@@ -258,8 +240,7 @@ For any
 \begin_inset Formula $L\geq0$
 \end_inset
 
-,
- a function 
+, a function 
 \begin_inset Formula $f:V\rightarrow W$
 \end_inset
 
@@ -356,8 +337,7 @@ A function
 \end_inset
 
 .
- Equivalently,
- 
+ Equivalently, 
 \begin_inset Formula $f$
 \end_inset
 
@@ -376,8 +356,10 @@ A function
 
 \end_inset
 
-The function is lower semi-continuous if is it so at every point in its domain.
- The definition of upper semi-continuous is analogous with the inequalities reversed and 
+The function is lower semi-continuous if is it so at every point in its
+ domain.
+ The definition of upper semi-continuous is analogous with the inequalities
+ reversed and 
 \begin_inset Formula $\liminf$
 \end_inset
 
@@ -410,8 +392,7 @@ For any
 \begin_inset Formula $g\in\mathcal{C}^{k+1}(\R)$
 \end_inset
 
-,
- and any 
+, and any 
 \begin_inset Formula $x$
 \end_inset
 
@@ -419,8 +400,7 @@ For any
 \begin_inset Formula $y$
 \end_inset
 
-,
- there is a 
+, there is a 
 \begin_inset Formula $\zeta\in[x,y]$
 \end_inset
 
@@ -475,8 +455,8 @@ A real symmetric matrix
 \end_inset
 
 .
- Equivalently,
- a real symmetric matrix with all nonnegative eigenvalues is PSD.
+ Equivalently, a real symmetric matrix with all nonnegative eigenvalues
+ is PSD.
  We write 
 \begin_inset Formula $A\succeq0$
 \end_inset
@@ -508,21 +488,15 @@ For any matrix
 \begin_inset Formula $A$
 \end_inset
 
-,
- we define its trace,
- 
+, we define its trace, 
 \begin_inset Formula $\tr A=\sum A_{ii}$
 \end_inset
 
-,
- Frobenius norm,
- 
+, Frobenius norm, 
 \begin_inset Formula $\,\|A\|_{F}^{2}=\tr(A^{\top}A)=\sum_{i,j}A_{ij}^{2}$
 \end_inset
 
-,
- and operator norm,
- 
+, and operator norm, 
 \begin_inset Formula $\,\|A\|_{\op}=\sup_{\|x\|_{2}=1}\|Ax\|_{2}$
 \end_inset
 
@@ -531,8 +505,7 @@ For any matrix
 \begin_inset Formula $x^{\top}Ax=\tr(Axx^{\top})$
 \end_inset
 
- and in general,
- 
+ and in general, 
 \begin_inset Formula $\tr(AB)=\tr(BA)$
 \end_inset
 
@@ -544,13 +517,11 @@ For symmetric
 \begin_inset Formula $A$
 \end_inset
 
-,
- we have 
+, we have 
 \begin_inset Formula $\tr A=\sum_{i}\lambda_{i}$
 \end_inset
 
-,
- 
+, 
 \begin_inset Formula $\|A\|_{F}^{2}=\sum_{i}\lambda_{i}^{2}$
 \end_inset
 
@@ -574,18 +545,15 @@ For a vector
 \begin_inset Formula $x$
 \end_inset
 
-,
- 
+, 
 \begin_inset Formula $\norm x_{A}=\sqrt{x^{T}Ax}$
 \end_inset
 
-;
- for a matrix 
+; for a matrix 
 \begin_inset Formula $B$
 \end_inset
 
-,
- 
+, 
 \begin_inset Formula 
 \[
 \norm B_{A}=\sup_{x}\frac{\norm{Bx}_{A}}{\norm x_{A}}.
@@ -614,8 +582,7 @@ Sherman-Morrison-Woodbury
 \begin_inset Formula $u,v\in\R^{n}$
 \end_inset
 
-,
- we have
+, we have
 \begin_inset Formula 
 \[
 \left(A+uv^{\top}\right)^{-1}=A^{-1}-\frac{A^{-1}uv^{\top}A^{-1}}{1+u^{\top}Av}.
@@ -679,6 +646,12 @@ distances
 \end_layout
 
 \begin_layout Definition
+\begin_inset CommandInset label
+LatexCommand label
+name "defn:KL-divergence"
+
+\end_inset
+
 The KL-divergence of a density 
 \begin_inset Formula $\rho$
 \end_inset
@@ -687,8 +660,7 @@ The KL-divergence of a density
 \begin_inset Formula $\nu$
 \end_inset
 
-,
- also known as relative entropy of 
+, also known as relative entropy of 
 \begin_inset Formula $\rho$
 \end_inset
 
@@ -696,8 +668,7 @@ The KL-divergence of a density
 \begin_inset Formula $\nu$
 \end_inset
 
-,
- is 
+, is 
 \begin_inset Formula 
 \[
 \KL(\rho\|v)=\int\rho(x)\log\frac{\rho(x)}{\nu(x)}dx.
@@ -728,9 +699,7 @@ The
 \begin_inset Formula $\nu$
 \end_inset
 
- is defined as 
-\backslash
-nu 
+ is defined as  
 \begin_inset Formula 
 \[
 \chi^{2}(\rho,\nu)=\E_{\nu}\left(\left(\frac{\rho(x)}{\nu(x)}-1\right)^{2}\right)=\E_{\rho}\left(\frac{\rho(x)}{\nu(x)}\right)-1.
@@ -824,8 +793,7 @@ name "def:p-dist"
 \begin_inset Formula $\R^{n}$
 \end_inset
 
-,
- the 
+, the 
 \emph on
 
 \begin_inset Formula $f$
@@ -845,8 +813,7 @@ name "def:p-dist"
 \begin_inset Formula $\mu\ll\nu$
 \end_inset
 
- is defined as,
- for a convex function 
+ is defined as, for a convex function 
 \begin_inset Formula $f:\R_{+}\to\R$
 \end_inset
 
@@ -858,8 +825,7 @@ name "def:p-dist"
 \begin_inset Formula $f'(\infty)=\infty$
 \end_inset
 
-,
- 
+, 
 \begin_inset Formula 
 \[
 D_{f}(\mu\|\nu):=\int f\left(\frac{d\mu}{d\nu}\right)\,d\nu\,.
@@ -871,8 +837,7 @@ For
 \begin_inset Formula $q\in(1,\infty)$
 \end_inset
 
-,
- the 
+, the 
 \emph on
 
 \begin_inset Formula $\KL$
@@ -892,8 +857,7 @@ For
 \begin_inset Formula $x^{q}-1$
 \end_inset
 
-,
- respectively.
+, respectively.
  The 
 \emph on
 
@@ -1043,7 +1007,8 @@ for any
 \end_layout
 
 \begin_layout Definition
-Note that the marginal is a convolution of the density with the indicator function of the subspace.
+Note that the marginal is a convolution of the density with the indicator
+ function of the subspace.
  
 \end_layout
 
@@ -1088,8 +1053,7 @@ We denote the unit Euclidean ball as
 \begin_inset Formula $B^{n}=\left\{ x:\norm x_{2}\le1\right\} .$
 \end_inset
 
- More generally,
- we define the 
+ More generally, we define the 
 \begin_inset Formula $\ell_{p}$
 \end_inset
 


### PR DESCRIPTION
- Fixed minor typos and a formatting issue regarding a section with *.
- Added a footnote about (dW_t)^2 = dt.
- Added a cross-reference to the definition of KL for readers' convenience.

P.S. Only commit lyx files so the main pdf doesn't lead to any conflict.