### PR TITLE
gradient & geometry exercises

### DIFF
--- a/ball_walk.lyx
+++ b/ball_walk.lyx
@@ -3642,6 +3642,12 @@ For convex bodies,
 \end_layout
 
 \begin_layout Theorem
+\begin_inset CommandInset label
+LatexCommand label
+name "thm:isotropic-r-R"
+
+\end_inset
+
 For a convex body in isotropic position (i.e.,
  the uniform distribution over the body is isotropic),
  we have
@@ -3653,6 +3659,35 @@ For a convex body in isotropic position (i.e.,
 \end_inset
 
 
+\end_layout
+
+\begin_layout Exercise
+Show Theorem 
+\begin_inset CommandInset ref
+LatexCommand ref
+reference "thm:isotropic-r-R"
+plural "false"
+caps "false"
+noprefix "false"
+nolink "false"
+
+\end_inset
+
+ up to absolute constants,
+ i.e.,
+ show that for any convex body in isotropic position,
+ it contains and is contained in origin-centered balls of radii 
+\begin_inset Formula $\Omega(1)$
+\end_inset
+
+ and 
+\begin_inset Formula $O(n)$
+\end_inset
+
+,
+ respectively.
+ Moreover,
+ give an isotropic convex body where both of these bounds are tight up to absolute constants.
 \end_layout
 
 \begin_layout Standard

--- a/gradient_descent.lyx
+++ b/gradient_descent.lyx
@@ -2383,7 +2383,7 @@ nolink "false"
 \end_layout
 
 \begin_layout Standard
-A similar bound also holds for convergence to the optimal point.
+A similar bound also holds for convergence to the optimal point and for convergence of the gradient's norm.
  
 \end_layout
 
@@ -2426,6 +2426,51 @@ Let
 \begin_inset Formula 
 \[
 \|x^{(k)}-x^{*}\|_{2}^{2}\le\left(1-\frac{\mu}{L}\right)^{k}\left\Vert x^{(0)}-x^{*}\right\Vert _{2}^{2}.
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset Separator plain
+\end_inset
+
+
+\end_layout
+
+\begin_layout Exercise
+Let 
+\begin_inset Formula $f\in\mathcal{C}^{2}(\R^{n})$
+\end_inset
+
+ be 
+\begin_inset Formula $\mu$
+\end_inset
+
+-strongly convex with 
+\begin_inset Formula $L$
+\end_inset
+
+-Lipschitz gradient.
+ With step size 
+\begin_inset Formula $h=1/L$
+\end_inset
+
+,
+ show that the sequence 
+\begin_inset Formula $x^{(k)}$
+\end_inset
+
+ in 
+\begin_inset Formula $\mathtt{GradientDescent}$
+\end_inset
+
+ satisfies
+\begin_inset Formula 
+\[
+||\nabla f(x^{(k+1)})||_{2}\leq\left(1-\frac{\mu}{L}\right)||\nabla f(x^{(k)})||_{2}
 \]
 
 \end_inset


### PR DESCRIPTION
Add exercise for showing geometric convergence of gradient under GD with strongly convex and L-smooth fn. Also add exercise for bounding diameter and inner radius of isotropic convex bodies, motivated by discussion in the lecture of Mar 9 and the homework.